### PR TITLE
RNMT-949 - Remove retries mechanism and change timer only to execute when there are logs on buffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode8.3
 before_install:
   - gem update cocoapods
   - pod setup --silent > /dev/null

--- a/Puree.podspec
+++ b/Puree.podspec
@@ -2,10 +2,10 @@ Pod::Spec.new do |s|
   s.name             = "Puree"
   s.version          = "2.0.1"
   s.summary          = "A log collector for iOS."
-  s.homepage         = "https://github.com/cookpad/puree-ios"
+  s.homepage         = "https://github.com/OutSystems/puree-ios"
   s.license          = "MIT"
   s.author           = { "Tomohiro Moro" => "tomohiro-moro@cookpad.com" }
-  s.source           = { :git => "https://github.com/cookpad/puree-ios.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/OutSystems/puree-ios.git", :tag => s.version.to_s }
 
   s.platform     = :ios, '7.0'
   s.requires_arc = true


### PR DESCRIPTION
- Remove retries mechanism to be the plugin decide if sync or not the logs
- Stop and restart the timer loop to only try sync data when there are logs on the buffer