### PR TITLE
RNMT-1251 Resuming app in iOS

### DIFF
--- a/Pod/Classes/PURBufferedOutput.m
+++ b/Pod/Classes/PURBufferedOutput.m
@@ -135,12 +135,7 @@ NSUInteger PURBufferedOutputDefaultMaxRetryCount = 3;
 }
 
 - (void)emitLog:(PURLog *)log
-{
-    //When new logger is emitted, restart the timer if it is invalid
-    if(![self.timer isValid]){
-        [self setUpTimer];
-    }
-    
+{    
     [self.buffer addObject:log];
     [self.logStore addLog:log forOutput:self completion:^{
         if ([self.buffer count] >= self.logLimit) {
@@ -154,7 +149,6 @@ NSUInteger PURBufferedOutputDefaultMaxRetryCount = 3;
     self.recentFlushTime = CFAbsoluteTimeGetCurrent();
 
     if ([self.buffer count] == 0) {
-        [self.timer invalidate];
         return;
     }
 


### PR DESCRIPTION
Rollback of the implementation to stop the timer when there are no logs on the buffer and restart when emitted a new log.

Problem:  When the app goes to foreground, the buffer won't be repopulated because of the timer is invalid.  